### PR TITLE
Stops keyboard observation from squashing insets and enables UIAppearance

### DIFF
--- a/JTSTextView Source/JTSTextView.h
+++ b/JTSTextView Source/JTSTextView.h
@@ -39,8 +39,7 @@
 
 @interface JTSTextView : UIScrollView
 
-- (instancetype)initWithFrame:(CGRect)frame
-                  textStorage:(NSTextStorage*)textStorage;
+- (instancetype)initWithFrame:(CGRect)frame textStorage:(NSTextStorage *)textStorage;
 
 @property (weak, nonatomic) id <JTSTextViewDelegate> textViewDelegate;
 @property (copy, nonatomic) NSAttributedString *attributedText;
@@ -48,31 +47,33 @@
 
 @property (assign, nonatomic) BOOL automaticallyAdjustsContentInsetForKeyboard; // Defaults to YES
 
-@property(nonatomic,retain) UIFont *font;
-@property(nonatomic,retain) UIColor *textColor;
-@property(nonatomic) NSTextAlignment textAlignment;    // default is NSLeftTextAlignment
-@property(nonatomic) NSRange selectedRange;
-@property(nonatomic,getter=isEditable) BOOL editable;
-@property(nonatomic,getter=isSelectable) BOOL selectable NS_AVAILABLE_IOS(7_0); // toggle selectability, which controls the ability of the user to select content and interact with URLs & attachments
-@property(nonatomic) UIDataDetectorTypes dataDetectorTypes NS_AVAILABLE_IOS(3_0);
-@property(nonatomic) BOOL allowsEditingTextAttributes NS_AVAILABLE_IOS(6_0); // defaults to NO
-@property(nonatomic,copy) NSDictionary *typingAttributes NS_AVAILABLE_IOS(6_0); // automatically resets when the selection changes
-@property(nonatomic, strong) UIView *jts_inputView;
-@property(nonatomic, strong) UIView *jts_inputAccessoryView;
-@property(nonatomic) BOOL clearsOnInsertion NS_AVAILABLE_IOS(6_0);
-@property(nonatomic,readonly) NSTextContainer *textContainer NS_AVAILABLE_IOS(7_0);
-@property(nonatomic, assign) UIEdgeInsets textContainerInset NS_AVAILABLE_IOS(7_0);
-@property(nonatomic,readonly) NSLayoutManager *layoutManager NS_AVAILABLE_IOS(7_0);
-@property(nonatomic,readonly,retain) NSTextStorage *textStorage NS_AVAILABLE_IOS(7_0); 
-@property(nonatomic, copy) NSDictionary *linkTextAttributes NS_AVAILABLE_IOS(7_0);
-@property(nonatomic) UITextAutocapitalizationType autocapitalizationType; 
-@property(nonatomic) UITextAutocorrectionType autocorrectionType;
-@property(nonatomic) UITextSpellCheckingType spellCheckingType NS_AVAILABLE_IOS(5_0);
-@property(nonatomic) UIKeyboardType keyboardType;
-@property(nonatomic) UIKeyboardAppearance keyboardAppearance;
-@property(nonatomic) UIReturnKeyType returnKeyType;
-@property(nonatomic) BOOL enablesReturnKeyAutomatically;
-@property(nonatomic,getter=isSecureTextEntry) BOOL secureTextEntry;
+@property (strong, nonatomic) UIFont *font UI_APPEARANCE_SELECTOR;
+@property (strong, nonatomic) UIColor *textColor UI_APPEARANCE_SELECTOR;
+@property (assign, nonatomic) NSTextAlignment textAlignment;    // default is NSLeftTextAlignment
+@property (assign, nonatomic) NSRange selectedRange;
+@property (assign, nonatomic, getter=isEditable) BOOL editable;
+@property (assign, nonatomic, getter=isSelectable) BOOL selectable; // toggle selectability, which controls the ability of the user to select content and interact with URLs & attachments
+@property (assign, nonatomic) UIDataDetectorTypes dataDetectorTypes;
+@property (assign, nonatomic) BOOL allowsEditingTextAttributes; // defaults to NO
+@property (copy, nonatomic) NSDictionary *typingAttributes; // automatically resets when the selection changes
+
+@property (strong, nonatomic) UIView *jts_inputView;
+@property (strong, nonatomic) UIView *jts_inputAccessoryView;
+
+@property (assign, nonatomic) BOOL clearsOnInsertion;
+@property (strong, nonatomic, readonly) NSTextContainer *textContainer;
+@property (assign, nonatomic) UIEdgeInsets textContainerInset;
+@property (strong, nonatomic, readonly) NSLayoutManager *layoutManager;
+@property (strong, nonatomic, readonly) NSTextStorage *textStorage;
+@property (copy, nonatomic) NSDictionary *linkTextAttributes;
+@property (assign, nonatomic) UITextAutocapitalizationType autocapitalizationType;
+@property (assign, nonatomic) UITextAutocorrectionType autocorrectionType;
+@property (assign, nonatomic) UITextSpellCheckingType spellCheckingType;
+@property (assign, nonatomic) UIKeyboardType keyboardType;
+@property (assign, nonatomic) UIKeyboardAppearance keyboardAppearance;
+@property (assign, nonatomic) UIReturnKeyType returnKeyType;
+@property (assign, nonatomic) BOOL enablesReturnKeyAutomatically;
+@property (assign, nonatomic, getter=isSecureTextEntry) BOOL secureTextEntry;
 
 - (void)scrollRangeToVisible:(NSRange)range;
 - (void)insertText:(NSString *)text;

--- a/JTSTextView Source/JTSTextView.m
+++ b/JTSTextView Source/JTSTextView.m
@@ -31,6 +31,16 @@
 
 @implementation JTSTextView
 
++ (void)initialize {
+    // Configure the default appearance
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [[self appearance] setBackgroundColor:[UIColor whiteColor]];
+        [[self appearance] setFont:[UIFont systemFontOfSize:17.0]];
+        [[self appearance] setTextColor:[UIColor blackColor]];
+    });
+}
+
 - (instancetype)initWithFrame:(CGRect)frame
                   textStorage:(NSTextStorage*)textStorage {
     self = [super initWithFrame:frame];
@@ -58,8 +68,6 @@
 }
 
 - (void)commonInitWithTextStorage:(NSTextStorage*)textStorage {
-    [self setBackgroundColor:[UIColor whiteColor]];
-
     [self setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth];
     
     // Setup TextKit stack for the private text view.
@@ -76,10 +84,6 @@
     [self.textView setAlwaysBounceVertical:NO];
     [self.textView setScrollsToTop:NO];
     [self.textView setDelegate:self];
-    
-    NSDictionary *defaltAttributes = @{NSFontAttributeName:[UIFont systemFontOfSize:17],
-                                       NSForegroundColorAttributeName:[UIColor blackColor]};
-    [self.textView setAttributedText:[[NSAttributedString alloc] initWithString:@" " attributes:defaltAttributes]];
     
     // Observes keyboard changes by default
     [self setAutomaticallyAdjustsContentInsetForKeyboard:YES];

--- a/Xcode Project/JSTTextView/JTSViewController.m
+++ b/Xcode Project/JSTTextView/JTSViewController.m
@@ -25,7 +25,7 @@
     [self.view addSubview:textView];
     [self setTextView:textView];
     
-    [self.textView setText:@"Me and my dad make models of clipper ships. Clipper ships sail on the ocean. Clipper ships never sail on rivers or lakes. I like clipper ships because they are fast. Clipper ships have lots of sails and are made of wood. "];
+    [self.textView setAttributedText:[[NSAttributedString alloc] initWithString:@"Me and my dad make models of clipper ships. Clipper ships sail on the ocean. Clipper ships never sail on rivers or lakes. I like clipper ships because they are fast. Clipper ships have lots of sails and are made of wood. "]];
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Toggle Keyboard" style:UIBarButtonItemStyleDone target:self action:@selector(toggle:)];
 }


### PR DESCRIPTION
The first commit fixes an issue where the scroll view's original `contentInset.bottom` and `scrollIndicatorInset.bottom` were overwritten when the keyboard is dismissed.

The second commit cleans up the property definitions to be consistent with the rest of the project and removes unnecessary `NS_AVAILABLE_IOS(...)` macros, since this relies on iOS 7.0 anyway. It also adds support for `UIAppearance`, and sets the defaults previously set in the `-commonInitWithTextStorage:` method. In the example application, I also changed the text-view from using a normal string to an attributed string to verify that the appearance selectors carried through to the attributed text.